### PR TITLE
fix(msa): Be more robust to nulls in a3m files.

### DIFF
--- a/src/atomworks/ml/transforms/msa/_msa_loading_utils.py
+++ b/src/atomworks/ml/transforms/msa/_msa_loading_utils.py
@@ -163,6 +163,9 @@ def parse_a3m(
     fstream = remove_header_from_msa_file(open_file(filename))
 
     for index, line in enumerate(fstream):
+        line = line.replace('\x00','') # Files from the mmseq server may have stray null characters
+        if len(line) == 0:
+            continue
         # Extract taxonomy ID from the header line, but don't process like the rest of the MSA
         if line[0] == ">":
             if index == 0:

--- a/src/atomworks/ml/transforms/msa/_msa_loading_utils.py
+++ b/src/atomworks/ml/transforms/msa/_msa_loading_utils.py
@@ -163,7 +163,7 @@ def parse_a3m(
     fstream = remove_header_from_msa_file(open_file(filename))
 
     for index, line in enumerate(fstream):
-        line = line.replace('\x00','') # Files from the mmseq server may have stray null characters
+        line = line.replace("\x00", "")  # Files from the mmseq server may have stray null characters
         if len(line) == 0:
             continue
         # Extract taxonomy ID from the header line, but don't process like the rest of the MSA


### PR DESCRIPTION
The MMseqs2 server can return .a3m files with a null character at the end of the file. This currently messes up parsing. Strip this character out of the file, as it has no semantic meaning.

## 📋 PR Checklist

- [x] This PR is tagged as a [draft](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/) if it is still under development and not ready for review. 
    > This avoids auto-triggering the slower tests in the CI and needlessly wasting resources.

- [x] I have ensured that all my commits follow [angular commit message conventions](https://www.conventionalcommits.org/en/v1.0.0-beta.4/).
    > Format: `<type>[optional scope]: <subject>`  
    > Example: `fix(af3): add missing crop transform to the af3 pipeline`
    >
    > This affects semantic versioning as follows:
    > - `fix`: patch version increment (0.0.1 → 0.0.2)
    > - `feat`: minor version increment (0.0.1 → 0.1.0) 
    > - `BREAKING CHANGE`: major version increment (0.0.1 → 1.0.0)
    > - All other types do not affect versioning
    >
    > The format ensures readable changelogs through auto-generation from commit messages.

- [x] I have run `make format` on the codebase before submitting the PR (this autoformats the code and lints it).

- [x] I have named the PR in angular PR message format as well (c.f. above), with a sensible tag line that summarizes all the changes in the PR. 
    > This is useful as the name of the PR is the default name of the commit that will be used if you merge with a squash & merge.
    > Format: `<type>[optional scope]: <subject>`  
    > Example: `fix(af3): add missing crop transform to the af3 pipeline`

---

## ℹ️ PR Description

### What changes were made and why?

The MMseqs2 server can return .a3m files with a null character at the end of the file.
This currently messes up parsing. Strip this character out of the file, as it has no semantic meaning.

### How were the changes tested?

The modifications were performed in conjunction with RF3, which allowed reading of an a3m file which previously caused a failure.

Writing of a unit test was considered, but it looks like no tests for the MSA parsing currently exist.

### Additional Notes

Should address RosettaCommons/modelforge#13

(Also, `make format` is changing much more than what I altered. If this part of anticipated PR process for new contributors, it would be best to keep production clean.)
