### PR TITLE
fix: add CITATION.cff for Zenodo integration

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,90 @@
+cff-version: 1.2.0
+title: atomworks
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - family-names: Corley
+    given-names: Nathaniel
+  - family-names: Mathis
+    given-names: Simon
+  - family-names: Krishna
+    given-names: Rohith
+  - family-names: Bauer
+    given-names: Magnus S.
+  - family-names: Thompson
+    given-names: Tuscan R.
+  - family-names: Ahern
+    given-names: Woody
+  - family-names: Kazman
+    given-names: Maxwell W.
+  - family-names: Brent
+    given-names: Rafael I.
+  - family-names: Didi
+    given-names: Kieran
+  - family-names: Kubaney
+    given-names: Andrew
+  - family-names: McHugh
+    given-names: Liam
+  - family-names: Nagle
+    given-names: Andrew
+  - family-names: Favor
+    given-names: Adam
+  - family-names: Kshirsagar
+    given-names: Meghana
+  - family-names: Sturmfels
+    given-names: Pascal
+  - family-names: Li
+    given-names: Yinuo
+  - family-names: Butcher
+    given-names: John
+  - family-names: Qiang
+    given-names: Bo
+  - family-names: Schaaf
+    given-names: Luna L.
+  - family-names: Mitra
+    given-names: Ria
+  - family-names: Campbell
+    given-names: Kerrie
+  - family-names: Zhang
+    given-names: Opa
+  - family-names: Weissman
+    given-names: Rose
+  - family-names: Humphreys
+    given-names: Ian R.
+  - family-names: Cong
+    given-names: Qian
+  - family-names: Jiang
+    given-names: Hanlun
+  - family-names: Funk
+    given-names: Jason
+  - family-names: Sonthalia
+    given-names: Satyaki
+  - family-names: Lio
+    given-names: Pietro
+  - family-names: Baker
+    given-names: David
+  - family-names: DiMaio
+    given-names: Frank
+identifiers:
+  - type: doi
+    value: 10.1101/2025.08.14.670328
+    description: bioRxiv preprint
+repository-code: https://github.com/RosettaCommons/atomworks
+url: https://rosettacommons.github.io/atomworks/latest/
+abstract: >-
+  A research-oriented data toolkit for training biomolecular
+  deep-learning foundation models. AtomWorks provides tools
+  for parsing, cleaning, manipulating, and converting
+  biological data (structures, sequences, small molecules)
+  as well as advanced dataset featurization and sampling for
+  deep learning workflows.
+keywords:
+  - bioinformatics
+  - machine-learning
+  - deep-learning
+  - protein-structure
+  - biotite
+  - structural-biology
+license: BSD-3-Clause

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ We thank Hope Woods and Rachel Clune from the Rosetta Commons for their partners
 
 If you make use of AtomWorks in your research, please cite:
 
-> N. Corley\*, S. Mathis\*, R. Krishna\*, M. S. Bauer, T. R. Thompson, W. Ahern, M. W. Kazman, R. I. Brent, K. Didi, A. Kubaney, L. McHugh, A. Nagle, A. Favor, M. Kshirsagar, P. Sturmfels, Y. Li, J. Butcher, B. Qiang, L. L. Schaaf, R. Mitra, K. Campbell, O. Zhang, R. Weissman, I. R. Humphreys, Q. Cong, J. Funk, S. Sonthalia, P. Lio, D. Baker, F. DiMaio,
+> N. Corley\*, S. Mathis\*, R. Krishna\*, M. S. Bauer, T. R. Thompson, W. Ahern, M. W. Kazman, R. I. Brent, K. Didi, A. Kubaney, L. McHugh, A. Nagle, A. Favor, M. Kshirsagar, P. Sturmfels, Y. Li, J. Butcher, B. Qiang, L. L. Schaaf, R. Mitra, K. Campbell, O. Zhang, R. Weissman, I. R. Humphreys, Q. Cong, H. Jiang, J. Funk, S. Sonthalia, P. Lio, D. Baker, F. DiMaio,
 > "Accelerating Biomolecular Modeling with AtomWorks and RF3," bioRxiv, August 2025. doi: [10.1101/2025.08.14.670328](https://doi.org/10.1101/2025.08.14.670328)
 
 If you use bibtex, here's the GoogleScholar formatted citation:


### PR DESCRIPTION
## Summary
- Adds `CITATION.cff` file with structured citation metadata for GitHub/Zenodo integration
- Updates README citation author list