### PR TITLE
fix: pin requires-python <3.13 to prevent pyarrow 17.x build failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "atomworks"
 version = "2.1.1"
 description = "A research-oriented data toolkit for training biomolecular deep-learning foundation models"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.13"
 authors = [
     { name = "Institute for Protein Design", email = "contact@ipd.uw.edu" }
 ]


### PR DESCRIPTION
## 📋 PR Checklist

- [x] This PR is tagged as a [draft](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/) if it is still under development and not ready for review. 
- [x] I have run `make format` on the codebase before submitting the PR (this autoformats the code and lints it).
- [x] I have named the PR in angular PR message format as well (c.f. above), with a sensible tag line that summarizes all the changes in the PR.
- [x] I have ensured that all my commits follow [angular commit message conventions](https://www.conventionalcommits.org/en/v1.0.0-beta.4/).

---

## ℹ️ PR Description

### What changes were made and why?

Added an upper bound `<3.13` to `requires-python` in `pyproject.toml`. Once the existing `# TODO: Test later versions` on `pyarrow==17.0.0` is resolved by upgrading to a version that ships Python 3.13 wheels, this pin can be removed.