### PR TITLE
docs: Adding Simple Analytics to the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,3 +95,7 @@ sphinx_gallery_conf = {
     "thumbnail_size": (350, 350),
     "default_thumb_file": "./_static/atomworks_logo_color.svg",
 }
+
+html_js_files = [
+     ('https://scripts.simpleanalyticscdn.com/latest.js', {'async': 'async', 'defer': 'defer'}),
+]


### PR DESCRIPTION
## 📋 PR Checklist

- [ ] This PR is tagged as a [draft](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/) if it is still under development and not ready for review. 
    > This avoids auto-triggering the slower tests in the CI and needlessly wasting resources.

- [ x] I have ensured that all my commits follow [angular commit message conventions](https://www.conventionalcommits.org/en/v1.0.0-beta.4/).
    > Format: `<type>[optional scope]: <subject>`  
    > Example: `fix(af3): add missing crop transform to the af3 pipeline`
    >
    > This affects semantic versioning as follows:
    > - `fix`: patch version increment (0.0.1 → 0.0.2)
    > - `feat`: minor version increment (0.0.1 → 0.1.0) 
    > - `BREAKING CHANGE`: major version increment (0.0.1 → 1.0.0)
    > - All other types do not affect versioning
    >
    > The format ensures readable changelogs through auto-generation from commit messages.

- [x ] I have run `make format` on the codebase before submitting the PR (this autoformats the code and lints it).

- [x ] I have named the PR in angular PR message format as well (c.f. above), with a sensible tag line that summarizes all the changes in the PR. 
    > This is useful as the name of the PR is the default name of the commit that will be used if you merge with a squash & merge.
    > Format: `<type>[optional scope]: <subject>`  
    > Example: `fix(af3): add missing crop transform to the af3 pipeline`

---

## ℹ️ PR Description

Added JS to the footer to link to [Simple Analytics](https://www.simpleanalytics.com/). The analytics account is managed by the Rosetta Commons Documentation Writer (Rachel Clune). Simple Analytics does not collect any personal information, even cookies. Only page view information will be used and only for project prioritization and reporting to the Rosetta Commons board. 

Reach out to Rachel Clune (rclune, rachel.clune@omsf.io) if you have any questions or concerns. 
