### PR TITLE
docs: Fix location of AF3_EXCLUDED_LIGANDS_REGEX

### DIFF
--- a/docs/mirrors.rst
+++ b/docs/mirrors.rst
@@ -82,7 +82,7 @@ Next we need to use the metadata to configure a dataset that we would like to sa
 Here's a simple example that:
 
 * Filters to D-polypeptide and L-polypeptide chains only (`POLYPEPTIDE_D` and `POLYPEPTIDE_L` -- to include additional chain types, replace the lists with the appropriate IDs (see [mapping](./src/atomworks/enums.py#L31-L45) in comments).
-* Excludes ligands in the AF3 list of excluded ligands, available at [`atomworks.io.constants.AF3_EXCLUDED_LIGANDS_REGEX`](./src/atomworks/constants.py#L350).
+* Excludes ligands in the AF3 list of excluded ligands, available at [`atomworks.constants.AF3_EXCLUDED_LIGANDS_REGEX`](./src/atomworks/constants.py#L350).
 
 .. code-block:: yaml
 


### PR DESCRIPTION
## 📋 PR Checklist

- [x] This PR is tagged as a [draft](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/) if it is still under development and not ready for review. 
- [x] I have ensured that all my commits follow [angular commit message conventions](https://www.conventionalcommits.org/en/v1.0.0-beta.4/).
- [n/a] I have run `make format` on the codebase before submitting the PR (this autoformats the code and lints it).
- [x] I have named the PR in angular PR message format as well (c.f. above), with a sensible tag line that summarizes all the changes in the PR. 

---

## ℹ️ PR Description

### What changes were made and why?

AF3_EXCLUDED_LIGANDS_REGEX is now in atomworks.constants vs. atomworks.io.constants

### How were the changes tested?

Double checked that atomworks.constants actually contained AF3_EXCLUDED_LIGANDS_REGEX in my local installation

### Additional Notes

A secondary issue here is that the cross-link to the Python file (in this line and the previous) does not work on the rendered version at <https://rosettacommons.github.io/atomworks/latest/mirrors.html> (Not sure if there's a good fix for that.)
