### PR TITLE
Fix version switcher URLs after Pages migration

### DIFF
--- a/.github/workflows/release_and_docs.yaml
+++ b/.github/workflows/release_and_docs.yaml
@@ -56,7 +56,10 @@ jobs:
           PYPI_REPO_URL: https://upload.pypi.org/legacy/
         run: |
           npx semantic-release
-          VERSION=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || echo "no-version")
+          # Only publish docs when semantic-release tagged this exact commit.
+          # Using the newest historical tag here would overwrite immutable
+          # version docs after a non-release production push.
+          VERSION=$(git describe --tags --exact-match --match "v*" HEAD 2>/dev/null || echo "no-version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Released version: $VERSION"
 

--- a/.github/workflows/release_and_docs.yaml
+++ b/.github/workflows/release_and_docs.yaml
@@ -117,7 +117,7 @@ jobs:
               fi
               
               if [[ "$v" == "latest" ]]; then
-                entry="{\"version\": \"latest\", \"url\": \"https://baker-laboratory.github.io/atomworks-dev/latest/index.html\", \"name\": \"latest\"}"
+                entry="{\"version\": \"latest\", \"url\": \"https://rosettacommons.github.io/atomworks/latest/index.html\", \"name\": \"latest\"}"
               else
                 disp="${v#v}"
                 # Mark the newest stable version as preferred
@@ -126,7 +126,7 @@ jobs:
                 else
                   preferred="false"
                 fi
-                entry="{\"version\": \"$disp\", \"url\": \"https://baker-laboratory.github.io/atomworks-dev/$v/index.html\", \"name\": \"v$disp\", \"preferred\": $preferred}"
+                entry="{\"version\": \"$disp\", \"url\": \"https://rosettacommons.github.io/atomworks/$v/index.html\", \"name\": \"v$disp\", \"preferred\": $preferred}"
               fi
               
               switcher_content="$switcher_content$entry"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ html_theme_options = {
     },
     "navbar_start": ["navbar-logo", "version-switcher"],
     "switcher": {
-        "json_url": "https://baker-laboratory.github.io/atomworks-dev/latest/_static/switcher.json",
+        "json_url": "https://rosettacommons.github.io/atomworks/latest/_static/switcher.json",
         "version_match": switcher_version,
     },
     "favicons": [


### PR DESCRIPTION
## Summary
- point Sphinx's version metadata at the RosettaCommons Pages host
- generate future release switcher entries with RosettaCommons version URLs
- deploy archived docs only when the current production commit has a release tag

## Test plan
- [x] Confirm every currently published version URL returns HTTP 200
- [x] Confirm no retired `baker-laboratory/atomworks-dev` Pages URLs remain in the source configuration
- [x] Confirm non-release commits resolve to `no-version` instead of reusing a historical tag